### PR TITLE
add support for "magick" converter (#1)

### DIFF
--- a/svg_preview.sublime-settings
+++ b/svg_preview.sublime-settings
@@ -1,0 +1,9 @@
+{
+    // Choses the prefered svg -> png converter.
+    // Only "inkscape" (default) and "magick" are supported.
+    // Those command must be visible in your PATH,
+    // alternatively you can put here a full path to the binary.
+    "converter": "inkscape"
+    // "converter": "magick"
+    // "converter": "/Applications/Inkscape.app/Contents/MacOS/inkscape"
+}


### PR DESCRIPTION
Add support for "magick" converter as suggested in #1.

But I have to say after experimenting with this plugin that magick may generate very bad svg preview,
and that Inkscape works better in my case.

The added setting file can also help for specifying the path to Inkscape it case ST doesn't see it.

`magick` also doesn't have an `--export-id` option, could you explain why is it used ? I'm not sure to understand.